### PR TITLE
add basic test for simplex primal tolerances

### DIFF
--- a/simplex_test.go
+++ b/simplex_test.go
@@ -92,6 +92,18 @@ func TestEasyPrimalSolve(t *testing.T) {
 	}
 }
 
+func TestGetSetSimplexPrimalTolerance(t *testing.T) {
+	simp := clp.NewSimplex()
+
+	initial := simp.GetPrimalTolerance()
+	simp.SetPrimalTolerance(initial*2.0)
+	reset := simp.GetPrimalTolerance()
+
+	if reset  != initial*2.0 {
+		t.Fatalf("Expected %f but observed %f", initial*2.0, reset)
+	}
+}
+
 // Maximize a + b subject to both 0 ≤ 2a + b ≤ 10 and 3 ≤ 2b − a ≤ 8.
 func ExampleSimplex_LoadProblem() {
 	// Set up the problem.


### PR DESCRIPTION
I don't really have a better test in terms of behaviour we were fixing as the models are quite verbose and distilling them down to a test case is not easy. This test verifies the round trip into the C++ lib and that it's at least setting the correct value.
