### PR TITLE
methods to get and set iteration and time limits

### DIFF
--- a/clp-interface.cxx
+++ b/clp-interface.cxx
@@ -154,4 +154,25 @@ extern "C" {
   {
     return ((ClpSimplex*)model)->objectiveValue();
   }
+
+  void set_max_iterations(clp_object* model, int max_iter)
+  {
+    ((ClpModel*)model)->setMaximumIterations(max_iter);
+  }
+
+  int max_iterations(clp_object* model)
+  {
+    return ((ClpModel*)model)->maximumIterations();
+  }
+
+  void set_max_seconds(clp_object* model, double max_seconds)
+  {
+    ((ClpModel*)model)->setMaximumSeconds(max_seconds);
+  }
+
+  double max_seconds(clp_object* model)
+  {
+    return ((ClpModel*)model)->maximumSeconds();
+  }
+
 }

--- a/clp-interface.h
+++ b/clp-interface.h
@@ -40,6 +40,11 @@ extern "C" {
   extern void simplex_primal_set_tolerance(clp_object* model, double tolerance);
   extern double simplex_primal_get_tolerance(clp_object* model);
 
+  extern void set_max_iterations(clp_object* model, int max_iter);
+  extern int max_iterations(clp_object* model);
+  extern void set_max_seconds(clp_object* model, double max_seconds);
+  extern double max_seconds(clp_object* model);
+
 #ifdef __cplusplus
 }
 #endif

--- a/simplex.go
+++ b/simplex.go
@@ -130,6 +130,22 @@ func (s *Simplex) SetOptimizationDirection(d OptDirection) {
 	C.simplex_set_opt_dir(s.model, C.double(d))
 }
 
+// Set max iterations for a solve
+func (s *Simplex) SetMaxIterations(maxIter int) {
+	C.set_max_iterations(s.model, C.int(maxIter))
+}
+func (s *Simplex) GetMaxIterations() int {
+	return int(C.max_iterations(s.model))
+}
+
+// Set max seconds for a solve
+func (s *Simplex) SetMaxSeconds(maxSeconds float64) {
+	C.set_max_seconds(s.model, C.double(maxSeconds))
+}
+func (s *Simplex) GetMaxSeconds() float64 {
+	return float64(C.max_seconds(s.model))
+}
+
 // A ValuesPass specifies whether to perform a values pass.
 type ValuesPass int
 

--- a/simplex_test.go
+++ b/simplex_test.go
@@ -15,6 +15,28 @@ func TestCreateSimplex(t *testing.T) {
 	_ = clp.NewSimplex()
 }
 
+// Test if we can set solve iteration limit.
+func TestSimplexSetIters(t *testing.T) {
+	s := clp.NewSimplex()
+	maxIter := 10
+	s.SetMaxIterations(maxIter)
+	maxIterBack := s.GetMaxIterations()
+	if maxIter != maxIterBack {
+		t.Fatal("Cannot set max iterations")
+	}
+}
+
+// Test if we can set solve time limit.
+func TestSimplexSetSeconds(t *testing.T) {
+	s := clp.NewSimplex()
+	maxSeconds := 12.1
+	s.SetMaxSeconds(maxSeconds)
+	maxSecondsBack := s.GetMaxSeconds()
+	if !closeTo(maxSeconds, maxSecondsBack, 0.05) {
+		t.Fatal("Cannot set max seconds")
+	}
+}
+
 // Test if we can load a problem into a simplex model.
 func TestLoadProblem(t *testing.T) {
 	s := clp.NewSimplex()


### PR DESCRIPTION
adds wrappers for set/get max iterations and max seconds.  along with tests.  the wrappers work on any clpmodel while the tests run on just the simplex object.