### PR TITLE
add SetDimensions

### DIFF
--- a/clp-interface.cxx
+++ b/clp-interface.cxx
@@ -18,6 +18,13 @@ extern "C" {
     ((CoinPackedMatrix*)matrix)->reserve(newMaxMajorDim, (CoinBigIndex)newMaxSize, bool(create));
   }
 
+  void set_dimensions (clp_object* matrix,
+		int numrows,
+		int numcols)
+  {
+    ((CoinPackedMatrix*)matrix)->setDimensions(numrows, numcols);
+  }
+
   // Free an existing CoinPackedMatrix.
   void free_packed_matrix (clp_object* matrix)
   {

--- a/clp-interface.h
+++ b/clp-interface.h
@@ -11,6 +11,7 @@ extern "C" {
   // Declare all of our wrapper functions.
   extern clp_object* new_packed_matrix (void);
   extern void reserve (clp_object* matrix, int newMaxMajorDim, int newMaxSize, int create);
+  extern void set_dimensions (clp_object* matrix, int numrows, int numcols);
   extern void free_packed_matrix (clp_object* matrix);
   extern void pm_append_col (clp_object* matrix, const int vecsize,
                              const int* vecind, const double* vecelem);

--- a/packed_matrix.go
+++ b/packed_matrix.go
@@ -44,6 +44,12 @@ func (pm *PackedMatrix) Reserve(newMaxMajorDim int, newMaxSize int, create bool)
 	C.reserve(pm.matrix, C.int(newMaxMajorDim), C.int(newMaxSize), b)
 }
 
+// SetDimensions reserves sufficient space in a packed matrix for appending
+// major-ordered vectors.
+func (pm *PackedMatrix) SetDimensions(numrows, numcols int) {
+	C.set_dimensions(pm.matrix, C.int(numrows), C.int(numcols))
+}
+
 // AppendColumn appends a sparse column to a packed matrix.  The column is
 // specified as a slice of {row number, value} pairs.
 func (pm *PackedMatrix) AppendColumn(col []Nonzero) {

--- a/simplex.go
+++ b/simplex.go
@@ -61,6 +61,25 @@ func (s *Simplex) LoadProblem(m Matrix, cb []Bounds, obj []float64, rb []Bounds,
 	// Get the matrix dimensions.
 	nr, nc := m.Dims()
 
+	// packed matrix does not count rows of 0
+	// nr is the length of the per-row vectors to allocate
+	// so ensure it is long enough to fit everything
+	if len(rb) > nr {
+		//		nr = len(rb)
+	}
+	if len(rowObj) > nr {
+		//		nr = len(rowObj)
+	}
+
+	// column count must match exactly
+	// packed matrix has a specified number of columns, all 0 still counts
+	if cb != nil && len(cb) != nc {
+		panic("column count mismatch 1")
+	}
+	if obj != nil && len(obj) != nc {
+		panic("column count mismatch 2")
+	}
+
 	// It's not safe to pass Go-allocated memory to C.  Hence, we use C's
 	// malloc to allocate the memory, which we free in the Simplex
 	// finalizer.  First, we convert cb to two C vectors, colLB and colUB.

--- a/simplex.go
+++ b/simplex.go
@@ -61,23 +61,18 @@ func (s *Simplex) LoadProblem(m Matrix, cb []Bounds, obj []float64, rb []Bounds,
 	// Get the matrix dimensions.
 	nr, nc := m.Dims()
 
-	// packed matrix does not count rows of 0
-	// nr is the length of the per-row vectors to allocate
-	// so ensure it is long enough to fit everything
-	if len(rb) > nr {
-		//		nr = len(rb)
+	if rb != nil && len(rb) != nr {
+		panic(fmt.Sprintf("clp: Simplex.LoadProblem incorrect number of row bounds %d vs %d", len(rb), nr))
 	}
-	if len(rowObj) > nr {
-		//		nr = len(rowObj)
+	if rowObj != nil && len(rowObj) != nr {
+		panic(fmt.Sprintf("clp: Simplex.LoadProblem incorrect length of row objective function %d vs %d", len(rowObj), nr))
 	}
 
-	// column count must match exactly
-	// packed matrix has a specified number of columns, all 0 still counts
 	if cb != nil && len(cb) != nc {
-		panic("column count mismatch 1")
+		panic(fmt.Sprintf("clp: Simplex.LoadProblem incorrect number of column bounds %d vs %d", len(cb), nc))
 	}
 	if obj != nil && len(obj) != nc {
-		panic("column count mismatch 2")
+		panic(fmt.Sprintf("clp: Simplex.LoadProblem incorrect length of objective function %d vs %d", len(obj), nc))
 	}
 
 	// It's not safe to pass Go-allocated memory to C.  Hence, we use C's

--- a/simplex_test.go
+++ b/simplex_test.go
@@ -92,41 +92,30 @@ func TestPrimalSolve(t *testing.T) {
 	}
 }
 
-func xxTestZeroSolve(t *testing.T) {
+func TestZeroSolve(t *testing.T) {
 	mat := clp.NewPackedMatrix()
 	mat.AppendColumn([]clp.Nonzero{
-		{Index: 0, Value: 0.0}, // a
-		{Index: 0, Value: 0.0}, // a
+		{Index: 0, Value: 1.0},
 	})
-	mat.AppendColumn([]clp.Nonzero{
-		{Index: 0, Value: 0.0}, // a
-		{Index: 0, Value: 0.0}, // a
-	})
+	// force a second all-0 row into the matrix
+   mat.SetDimensions(2,1)
 	rb := []clp.Bounds{
-		{Lower: 0, Upper: 0}, // [4, 9]
-		{Lower: 0, Upper: 0}, // [4, 9]
+		{Lower: 0, Upper: 0},
+		{Lower: 0, Upper: 0},
 	}
-	obj := []float64{1.0, 1.0} // a + 2b
+	obj := []float64{1.0}
 	simp := clp.NewSimplex()
 	simp.LoadProblem(mat, nil, obj, rb, nil)
 	simp.SetOptimizationDirection(clp.Minimize)
 
 	// Solve the optimization problem.
 	simp.Primal(clp.NoValuesPass, clp.NoStartFinishOptions)
-	v := simp.ObjectiveValue()
 	soln := simp.PrimalColumnSolution()
+   if soln == nil {
+      t.Error("got nil solution when testing Zero case")
+   }
+	// the real sign of success is that we got here without a panic
 
-	// Check the results.
-	if !closeTo(soln[0], 1.75, 0.005) || !closeTo(soln[1], 2.25, 0.005) {
-		t.Fatalf("Expected [1.75 2.25] but observed %v", soln)
-	}
-	if !closeTo(v, 6.25, 0.005) {
-		t.Fatalf("Expected 6.25 but observed %.10g", v)
-	}
-	secStatus := simp.SecondaryStatus()
-	if secStatus != clp.SecondaryNone {
-		t.Fatalf("Expected %d secondary status but got %d", clp.SecondaryNone, secStatus)
-	}
 }
 
 // Test if we can solve the same problem as above but with the "easy" interface.


### PR DESCRIPTION
Add PackedMatrix.SetDimensions with error checking.

Simplex.LoadProblem was not bounds-checking the constraint and objective function slices.  In cases where these slices were too long this ran off the end of unsafe.Pointer arrays.  Without SetDimensions there was no way to add empty rows at the bottom of a packedmatrix to get these sizes/lengths in line.